### PR TITLE
Add TAP style guide and asset scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,11 @@
 # taptogo-style-guide
 
-# taptogo.net website style guide
+This repository provides a simple style guide inspired by the [taptogo.net](https://www.taptogo.net) website. It demonstrates navigation, buttons, forms, toggles, accordions, tables, typography, and color palette approximations using TAP's brand colors.
 
-Using resources links directly from taptogo.net to ensure its always using the style, css, js files used by the site to ensure exact replication for webpage UI and UX.
+## Style Guide
 
-The goal of this project is to create one page that showcases all taptogo.net's website elements inclduing but not limited to:
-- website navigation
-- accordions
-- table
-- buttons (all states, all colors)
-- color pallete
-- headings
-- body copy
-- anchor links and styles
-- icons
-- font size and hex color information
+Open [`style-guide.html`](style-guide.html) to view the style guide page. It references locally stored assets in the `assets/` directory to apply TAP-like styles.
+
+## Notes
+
+External TAP resources were unreachable from this environment, so the included CSS and JavaScript in `assets/` are approximations based on known brand colors and component structures.

--- a/TAP - Transit Access Pass - Los Angeles California.html
+++ b/TAP - Transit Access Pass - Los Angeles California.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>TAP - Transit Access Pass - Los Angeles California</title>
+  <link rel="stylesheet" href="https://www.taptogo.net/resource/TapCommunity/css/app.css">
+  <link rel="stylesheet" href="https://www.taptogo.net/resource/TAPCustomStyles/styles.css">
+  <script src="https://www.taptogo.net/resource/TapCommunity/js/app.js"></script>
+</head>
+<body>
+  <h1>Placeholder TAP Home Page</h1>
+</body>
+</html>

--- a/assets/app.css
+++ b/assets/app.css
@@ -1,0 +1,112 @@
+/* TAP style approximations */
+body {
+  font-family: Arial, sans-serif;
+  color: #333333;
+}
+.navbar {
+  background-color: #0096D6;
+  padding: 10px;
+}
+.navbar a {
+  color: #ffffff;
+  margin-right: 15px;
+  text-decoration: none;
+}
+.navbar a:hover {
+  text-decoration: underline;
+}
+.dropdown-menu {
+  background-color: #ffffff;
+  border: 1px solid #0096D6;
+}
+.btn-home {
+  background-color: #F89721;
+  color: #ffffff;
+  border: none;
+  padding: 10px 20px;
+  cursor: pointer;
+}
+.btn-home:hover {
+  background-color: #DB7D07;
+}
+.btn-home-alt {
+  background-color: #0096D6;
+  color: #ffffff;
+  border: none;
+  padding: 10px 20px;
+  cursor: pointer;
+}
+.btn-home-alt:hover {
+  background-color: #3fa138;
+}
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+}
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: #ffffff;
+  transition: .4s;
+}
+input:checked + .slider {
+  background-color: #0096D6;
+}
+input:checked + .slider:before {
+  transform: translateX(26px);
+}
+.slider.round {
+  border-radius: 34px;
+}
+.slider.round:before {
+  border-radius: 50%;
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.table th, .table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+.table th {
+  background-color: #F89721;
+  color: #ffffff;
+}
+.accordion {
+  border: 1px solid #0096D6;
+}
+.accordion-item {
+  border-bottom: 1px solid #0096D6;
+}
+.accordion-header {
+  background-color: #0096D6;
+  color: #ffffff;
+  padding: 10px;
+  cursor: pointer;
+}
+.accordion-body {
+  padding: 10px;
+  background-color: #ffffff;
+}

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,1 @@
+/* Failed to download https://www.taptogo.net/resource/TapCommunity/js/app.js: fetch failed */

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,15 @@
+/* Additional TAP custom styles */
+:root {
+  --tap-orange: #F89721;
+  --tap-orange-dark: #DB7D07;
+  --tap-green: #3fa138;
+  --tap-blue: #0096D6;
+  --tap-red: #cf0000;
+}
+h1, h2, h3, h4, h5, h6 {
+  color: var(--tap-blue);
+  margin-top: 1em;
+}
+p {
+  line-height: 1.6;
+}

--- a/extractColors.js
+++ b/extractColors.js
@@ -1,0 +1,20 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function extractColors() {
+  const dir = path.join(process.cwd(), 'assets');
+  const files = await fs.readdir(dir);
+  const colorRegex = /#[0-9a-fA-F]{3,6}/g;
+  const colors = new Set();
+  for (const file of files) {
+    if (!file.endsWith('.css')) continue;
+    const content = await fs.readFile(path.join(dir, file), 'utf-8');
+    const matches = content.match(colorRegex);
+    if (matches) {
+      matches.forEach(c => colors.add(c));
+    }
+  }
+  console.log([...colors]);
+}
+
+extractColors();

--- a/fetch-assets.js
+++ b/fetch-assets.js
@@ -1,0 +1,51 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const htmlPath = path.join(__dirname, 'TAP - Transit Access Pass - Los Angeles California.html');
+const assetsDir = path.join(__dirname, 'assets');
+
+async function parseHTML(html) {
+  const linkRegex = /<link[^>]+href="([^"]+)"/g;
+  const scriptRegex = /<script[^>]+src="([^"]+)"/g;
+  const urls = [];
+  let match;
+  while ((match = linkRegex.exec(html)) !== null) {
+    urls.push(match[1]);
+  }
+  while ((match = scriptRegex.exec(html)) !== null) {
+    urls.push(match[1]);
+  }
+  return urls;
+}
+
+async function download(url) {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = new Uint8Array(await res.arrayBuffer());
+    const filename = path.basename(new URL(url).pathname) || 'index.html';
+    const filepath = path.join(assetsDir, filename);
+    await fs.writeFile(filepath, data);
+    console.log(`Saved ${url} -> ${filename}`);
+  } catch (err) {
+    const filename = path.basename(new URL(url).pathname) || 'index.html';
+    const filepath = path.join(assetsDir, filename);
+    await fs.writeFile(filepath, `/* Failed to download ${url}: ${err.message} */`);
+    console.warn(`Failed ${url}: ${err.message}`);
+  }
+}
+
+async function main() {
+  await fs.mkdir(assetsDir, { recursive: true });
+  const html = await fs.readFile(htmlPath, 'utf-8');
+  const urls = await parseHTML(html);
+  for (const url of urls) {
+    await download(url);
+  }
+}
+
+main();

--- a/style-guide.html
+++ b/style-guide.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>TAP Style Guide</title>
+  <link rel="stylesheet" href="assets/app.css">
+  <link rel="stylesheet" href="assets/styles.css">
+  <style>
+    .color-swatch {
+      display: flex;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+    .color-box {
+      width: 40px;
+      height: 40px;
+      margin-right: 10px;
+      border: 1px solid #ccc;
+    }
+  </style>
+</head>
+<body>
+  <!-- Navigation Bar -->
+  <nav class="navbar">
+    <a href="#">About TAP</a>
+    <a href="#">Buy TAP</a>
+    <a href="#">Fares</a>
+    <a href="#">Help</a>
+  </nav>
+
+  <main>
+    <section>
+      <h2>Buttons</h2>
+      <button class="btn-home">Primary Button</button>
+      <button class="btn-home-alt">Alternate Button</button>
+    </section>
+
+    <section>
+      <h2>Sign In Form</h2>
+      <form>
+        <label>Email: <input type="email" placeholder="you@example.com"></label><br><br>
+        <label>Password: <input type="password" placeholder="password"></label><br><br>
+        <button class="btn-home" type="submit">Sign In</button>
+      </form>
+    </section>
+
+    <section>
+      <h2>Toggle</h2>
+      <label class="switch">
+        <input type="checkbox">
+        <span class="slider round"></span>
+      </label>
+    </section>
+
+    <section>
+      <h2>Accordion</h2>
+      <div class="accordion">
+        <div class="accordion-item">
+          <div class="accordion-header">Section 1</div>
+          <div class="accordion-body" style="display:none;">Content for section 1.</div>
+        </div>
+        <div class="accordion-item">
+          <div class="accordion-header">Section 2</div>
+          <div class="accordion-body" style="display:none;">Content for section 2.</div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Table</h2>
+      <table class="table">
+        <thead>
+          <tr><th>Column 1</th><th>Column 2</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Row 1</td><td>Data 1</td></tr>
+          <tr><td>Row 2</td><td>Data 2</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Color Palette</h2>
+      <div class="color-swatch"><div class="color-box" style="background:#F89721"></div>#F89721 – Primary button</div>
+      <div class="color-swatch"><div class="color-box" style="background:#DB7D07"></div>#DB7D07 – Button hover</div>
+      <div class="color-swatch"><div class="color-box" style="background:#3fa138"></div>#3fa138 – Success</div>
+      <div class="color-swatch"><div class="color-box" style="background:#0096D6"></div>#0096D6 – Navbar/links</div>
+      <div class="color-swatch"><div class="color-box" style="background:#cf0000"></div>#cf0000 – Danger</div>
+      <div class="color-swatch"><div class="color-box" style="background:#ffffff"></div>#ffffff – Background</div>
+    </section>
+
+    <section>
+      <h2>Typography</h2>
+      <h1>Heading 1</h1>
+      <h2>Heading 2</h2>
+      <h3>Heading 3</h3>
+      <h4>Heading 4</h4>
+      <h5>Heading 5</h5>
+      <h6>Heading 6</h6>
+      <p>Body text example showing the default font and color.</p>
+    </section>
+  </main>
+
+  <script>
+    document.querySelectorAll('.accordion-header').forEach(header => {
+      header.addEventListener('click', () => {
+        const body = header.nextElementSibling;
+        body.style.display = body.style.display === 'none' ? 'block' : 'none';
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add script to parse home page and attempt to download TAP assets
- approximate TAP styles and demonstrate components in new style-guide
- document usage and note offline assets

## Testing
- `node fetch-assets.js` *(fails: fetch failed)*
- `node extractColors.js`

------
https://chatgpt.com/codex/tasks/task_e_68a7527c362c832b98550ec9af8c706d