### PR TITLE
Add meta viewport and GitHub Pages notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This repository provides a simple style guide inspired by the [taptogo.net](http
 
 Open [`style-guide.html`](style-guide.html) to view the style guide page. It references locally stored assets in the `assets/` directory to apply TAP-like styles.
 
+## GitHub Pages
+
+The repository is ready to be published with GitHub Pages. After enabling Pages in your repository settings, visit:
+
+```
+https://<username>.github.io/taptogo-style-guide/style-guide.html
+```
+
+to view the style guide online.
+
 ## Notes
 
 External TAP resources were unreachable from this environment, so the included CSS and JavaScript in `assets/` are approximations based on known brand colors and component structures.

--- a/style-guide.html
+++ b/style-guide.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TAP Style Guide</title>
   <link rel="stylesheet" href="assets/app.css">
   <link rel="stylesheet" href="assets/styles.css">


### PR DESCRIPTION
## Summary
- Ensure style guide is responsive by adding viewport meta tag
- Document how to publish and access the style guide via GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a75c945b40832bbe701848ddd7d23d