### PR TITLE
Add TAP external styles and scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TAP Style Guide</title>
-  <link rel="stylesheet" href="assets/app.css">
-  <link rel="stylesheet" href="assets/styles.css">
+  <link rel="stylesheet" href="https://www.taptogo.net/resource/1552006553000/TAPCustomStyles">
+  <link rel="stylesheet" href="https://www.taptogo.net/resource/1738884380000/TapCommunity/css/app.css">
   <style>
     .color-swatch {
       display: flex;
@@ -102,6 +102,8 @@
     </section>
   </main>
 
+  <script src="https://www.taptogo.net/resource/1738884380000/TapCommunity/js/bootstrap.min-min.js"></script>
+  <script src="https://www.taptogo.net/resource/1738884380000/TapCommunity/js/app.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reference TAP-hosted stylesheets for official styles
- load TAP-provided JavaScript and keep local script after them

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68a7606cc5f8832ba8c1f7a08c037ab1