### PR TITLE
Add button classes and HTML element showcase

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -5,6 +5,11 @@
   --tap-green: #3fa138;
   --tap-blue: #0096D6;
   --tap-red: #cf0000;
+  --tap-gray: #6c757d;
+  --tap-k12: #6610f2;
+  --tap-disabilities: #e83e8c;
+  --tap-college: #20c997;
+  --tap-senior: #fd7e14;
 }
 h1, h2, h3, h4, h5, h6 {
   color: var(--tap-blue);
@@ -12,4 +17,124 @@ h1, h2, h3, h4, h5, h6 {
 }
 p {
   line-height: 1.6;
+}
+
+/* Grid helpers */
+.container {
+  margin: 1rem 0;
+}
+.row {
+  display: flex;
+  flex-wrap: wrap;
+}
+.valign {
+  align-items: center;
+}
+.col {
+  flex: 1;
+  padding: 0.5rem;
+}
+.col-xs-12 {
+  width: 100%;
+}
+@media (min-width: 768px) {
+  .col-sm-9 {
+    width: 75%;
+  }
+}
+
+/* Button styles */
+.btn {
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 400;
+  padding: 6px 12px;
+  line-height: 1.5;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+
+.badge,
+.btn.badge {
+  border-radius: 20px;
+}
+
+.btn-default {
+  color: #333;
+  background-color: #fff;
+  border-color: #ccc;
+}
+
+.btn-primary {
+  background-color: var(--tap-orange);
+  border-color: var(--tap-orange-dark);
+  color: #fff;
+}
+
+.btn-secondary {
+  background-color: var(--tap-gray);
+  border-color: var(--tap-gray);
+  color: #fff;
+}
+
+.btn-k12students {
+  background-color: var(--tap-k12);
+  border-color: var(--tap-k12);
+  color: #fff;
+}
+
+.btn-disablilites {
+  background-color: var(--tap-disabilities);
+  border-color: var(--tap-disabilities);
+  color: #fff;
+}
+
+.btn-college {
+  background-color: var(--tap-college);
+  border-color: var(--tap-college);
+  color: #fff;
+}
+
+.btn-senior {
+  background-color: var(--tap-senior);
+  border-color: var(--tap-senior);
+  color: #fff;
+}
+
+.btn-success {
+  background-color: var(--tap-green);
+  border-color: var(--tap-green);
+  color: #fff;
+}
+
+.btn-info {
+  background-color: var(--tap-blue);
+  border-color: var(--tap-blue);
+  color: #fff;
+}
+
+.btn-warning {
+  background-color: var(--tap-orange-dark);
+  border-color: var(--tap-orange-dark);
+  color: #fff;
+}
+
+.btn-danger {
+  background-color: var(--tap-red);
+  border-color: var(--tap-red);
+  color: #fff;
+}
+
+.btn-link {
+  background-color: transparent;
+  border-color: transparent;
+  color: var(--tap-blue);
+}
+
+.btn-link:hover {
+  text-decoration: underline;
 }

--- a/index.html
+++ b/index.html
@@ -100,6 +100,162 @@
       <h6>Heading 6</h6>
       <p>Body text example showing the default font and color.</p>
     </section>
+
+    <section>
+      <div class="col-xs-12 col-sm-9">
+        <h1>HTML Elements List</h1>
+
+        <h1>Heading 1</h1>
+        <h2>Heading 2</h2>
+        <h3>Heading 3</h3>
+        <h4>Heading 4</h4>
+        <h5>Heading 5</h5>
+        <br>
+
+        <a href="#">Anchor Text</a>
+        <br><br>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-default" href="#">Button Default</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-default badge" href="#">Button Default Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-primary" href="#">Button Primary</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-primary badge" href="#">Button Primary Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-secondary" href="#">Button Secondary</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-secondary badge" href="#">Button Secondary Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-k12students" href="#">Button k12students</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-k12students badge" href="#">Button k12students Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-disablilites" href="#">Button Disablilites</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-disablilites badge" href="#">Button Disablilites Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-college" href="#">Button College</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-college badge" href="#">Button College Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-senior" href="#">Button Senior</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-senior badge" href="#">Button Senior Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-success" href="#">Button Success</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-success badge" href="#">Button Success Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-info" href="#">Button Info</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-info badge" href="#">Button Info Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-warning" href="#">Button Warning</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-warning badge" href="#">Button Warning Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-danger" href="#">Button Danger</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-danger badge" href="#">Button Danger Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="container">
+          <div class="row valign">
+            <div class="col">
+              <a class="btn btn-link" href="#">Button Link</a>
+            </div>
+            <div class="col">
+              <a class="btn btn-link badge" href="#">Button Link Badge</a>
+            </div>
+          </div>
+        </div>
+
+        <p>This is a paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+
+        <p>FAQ</p>
+
+        <p>Accordion non-faq</p>
+
+        <p>web elements such as re-used block layouts</p>
+      </div>
+    </section>
   </main>
 
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- define grid helpers and many button variants in `assets/styles.css`
- add HTML elements list in `index.html` demonstrating headings, links, and button badges

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a760b139e4832bb823ecf4781763b7