### PR TITLE
feat: expand style guide layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,14 @@
   <link rel="stylesheet" href="https://www.taptogo.net/resource/1552006553000/TAPCustomStyles">
   <link rel="stylesheet" href="https://www.taptogo.net/resource/1738884380000/TapCommunity/css/app.css">
   <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+    main {
+      flex: 1;
+    }
     .color-swatch {
       display: flex;
       align-items: center;
@@ -17,16 +25,6 @@
       height: 40px;
       margin-right: 10px;
       border: 1px solid #ccc;
-    }
-    .top-bar {
-      background: #0096D6;
-      color: #fff;
-      padding: 4px 0;
-    }
-    .top-bar a {
-      color: #fff;
-      margin-right: 15px;
-      text-decoration: none;
     }
     .navbar-account {
       background: #fff;
@@ -51,20 +49,177 @@
   </style>
 </head>
 <body>
-  <div class="top-bar">
-    <div class="container">
-      <a href="#">English</a>
-      <a href="#">Contact</a>
-    </div>
+  <div class="navbar navbar-default top-nav"><div id="j_id0:tapwrapper:ctHeader" class="container">
+        <div class="navbar-header">
+            <button class="navbar-toggle" data-target=".navbar-collapse" data-toggle="collapse" type="button">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+                <a class="navbar-brand" href="/">
+                    <img alt="TAP" src="/resource/1738884380000/TapCommunity/img/tap-logo-transparent.png">
+                </a>
+        </div>
+        <div class="collapse navbar-collapse navbar-flex-tap">
+
+
+          <div class="search-box-gsc-wrap header-search">
+            <form action="/TapSearchResults" id="searchForm" method="get">
+                <input class="search-field search-input-box" id="search" name="q" placeholder="Search..." size="25" type="text" aria-expanded="false">
+                <div class="search-icon-container inactive-desktop">
+                    <input class="search-icon icon-button inactive-mobile" id="searchIcon" type="submit" value=" ">
+                </div>
+            </form> 
+          </div>
+
+
+
+        <ul class="nav navbar-nav">
+             <li class="dropdown" role="presentation">
+              <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">About TAP
+              </a>
+              <ul class="dropdown-menu">
+                 <li>
+                    <a href="/articles/en_US/Website_content/about-tap">Overview
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/articles/en_US/Website_content/how-to-ride">How to TAP
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/articles/en_US/Website_content/where-to-ride">TAP Agencies
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/TAPFAQ">FAQs
+                    </a>
+                 </li>
+                 <li>
+                     <a href="/TAPAppFAQs">TAP App FAQs
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/PartnerNews">Partner News
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/commemorative-cards">Commemorative Cards
+                    </a>
+                 </li>
+              </ul>
+           </li>
+           <li class="dropdown" role="presentation">
+              <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">Buy TAP
+              </a>
+              <ul class="dropdown-menu">
+                 <li>
+                    <a href="/TAPPurchase">How to Buy and Reload a TAP Card
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/articles/en_US/Website_content/TAP-App">TAP App
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/TAPLocator2">Vendor Locations
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/articles/en_US/Website_content/Barcode-TAP-Cards">Barcode TAP Cards
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/articles/en_US/Website_content/stored-value">Stored Value
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/articles/en_US/Website_content/balance-protection">Balance Protection
+                    </a>
+                 </li>                                 
+                 <li>
+                    <a href="/articles/en_US/Website_content/fare-capping-on-metro">Fare Capping on Metro
+                    </a>
+                 </li>
+              </ul>
+           </li>
+           <li class="dropdown" role="presentation">
+              <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">Programs
+              </a>
+              <ul class="dropdown-menu">
+                 <li>
+                     <a href="/articles/en_US/Website_content/Transit">Transit
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/MetroBikeShare">Metro Bike Share
+                    </a>
+                 </li>
+              </ul>
+           </li>
+           <li class="dropdown" role="presentation">
+              <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">Discounts
+              </a>
+              <ul class="dropdown-menu">
+                 <li>
+                     <a href="/LIFE">LIFE (Low Income Fare is Easy)
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/Reduced_Fare">Reduced Fares
+                    </a>
+                 </li>
+              </ul>
+           </li>
+           <li class="dropdown" role="presentation">
+              <a aria-expanded="false" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" style="padding-right:0;">Group Sales
+              </a>
+              <ul class="dropdown-menu">
+                 <li>
+                    <a href="/articles/en_US/Website_content/Employer">TAP for Employers
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/articles/en_US/Website_content/GO-TAP">GO TAP
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/articles/en_US/Website_content/Non-profit">Non-Profit Organizations
+                    </a>
+                 </li>
+                 <li>
+                    <a href="/articles/en_US/Website_content/Social-Services">Social Service Organizations
+                    </a>
+                 </li>
+              </ul>
+           </li><span id="j_id0:tapwrapper:j_id72"></span>
+        </ul> 
+      
+
+      
+     </div></div> 
   </div>
   <div class="navbar navbar-account">
-    <div class="container">
-      <a href="#" class="brand">TAP</a>
-      <a href="#">About TAP</a>
-      <a href="#">Buy TAP</a>
-      <a href="#">Fares</a>
-      <a href="#">Help</a>
-    </div>
+      <div class="container">
+          <div class="navbar-header">
+                  <span class="account-welcome">Welcome and sign in.
+                  </span>&nbsp;&nbsp;
+                  <a href="/TapRegister">Create&nbsp;Account
+                  </a>&nbsp;&nbsp;&nbsp;
+                  <a href="/PortalForgotPassword?conf=taptogo">Change Password
+                  </a>
+          </div>
+<form id="j_id0:tapwrapper:loginform" name="j_id0:tapwrapper:loginform" method="post" action="https://www.taptogo.net/TAPHomePage?refURL=http%3A%2F%2Fwww.taptogo.net%2F" class="navbar-form navbar-right" enctype="application/x-www-form-urlencoded" data-gtm-form-interact-id="0">
+<input type="hidden" name="j_id0:tapwrapper:loginform" value="j_id0:tapwrapper:loginform">
+
+                  <div class="form-group"><label for="j_id0:tapwrapper:loginform:login-email" class="control-label sr-only">
+Email</label><input id="j_id0:tapwrapper:loginform:login-email" type="text" name="j_id0:tapwrapper:loginform:login-email" class="form-control input-sm" required="required" placeholder="Email" data-gtm-form-interact-field-id="0">
+                  </div>
+                  <div class="form-group"><label for="j_id0:tapwrapper:loginform:login-password" class="control-label sr-only">
+Password</label><input id="j_id0:tapwrapper:loginform:login-password" type="password" name="j_id0:tapwrapper:loginform:login-password" value="" title="Password" class="form-control input-sm" placeholder="Password" data-gtm-form-interact-field-id="1">
+                  </div><input id="j_id0:tapwrapper:loginform:login-submit" type="submit" name="j_id0:tapwrapper:loginform:login-submit" value="Sign in" style="color:#0096D6;background-color:#FFFFFF;border-color:#FFFFFF;font-weight:500;" class="btn btn-default btn-sm"><div id="j_id0:tapwrapper:loginform:j_id343"></div>
+</form><span id="ajax-view-state-page-container" style="display: none"><span id="ajax-view-state" style="display: none"><input type="hidden" id="com.salesforce.visualforce.ViewState" name="com.salesforce.visualforce.ViewState" value=""></span></span>
+      </div>
   </div>
 
   <div class="container">
@@ -143,14 +298,6 @@
     <section>
       <div class="col-xs-12 col-sm-9">
         <h1>HTML Elements List</h1>
-
-        <h1>Heading 1</h1>
-        <h2>Heading 2</h2>
-        <h3>Heading 3</h3>
-        <h4>Heading 4</h4>
-        <h5>Heading 5</h5>
-        <br>
-
         <a href="#">Anchor Text</a>
         <br><br>
 
@@ -306,10 +453,57 @@
       </div>
     </section>
   </main>
-  <footer>
-    <p>&copy; 2024 TAP Style Guide</p>
-  </footer>
   </div>
+  <footer class="footer">
+   <div class="container">
+
+      <div class="row">
+         <div class="col-xs-12 col-sm-2">
+            <ul class="list-unstyled">
+               <li><a href="/articles/en_US/Website_content/login-help">Login Help</a></li>
+               <li><a href="/TAPContact">Contact TAP</a></li>
+               <li><a href="/articles/en_US/Website_content/TAP-Vendor-Network">TAP Vendor Network</a></li>
+               <li><a href="/articles/en_US/Website_content/browser-support">Browser Support</a></li>
+               <li><a href="/TAPStatus">TAP Card Status</a></li>
+            </ul>
+         </div>
+         <div class="col-xs-12 col-sm-2">
+            <ul class="list-unstyled">
+               <li><a href="/articles/en_US/Website_content/Terms-of-Service">Terms of Service</a></li>
+               <li><a href="/articles/en_US/Website_content/Privacy-Notice">Privacy Notice</a></li><span id="j_id0:tapwrapper:j_id318" style="display: none;"></span>
+            </ul>
+         </div>
+         <div class="col-xs-12 col-sm-2 col-sm-push-6">
+<form id="j_id0:tapwrapper:j_id321" name="j_id0:tapwrapper:j_id321" method="post" action="/TAPHomePage" enctype="application/x-www-form-urlencoded">
+<input type="hidden" name="j_id0:tapwrapper:j_id321" value="j_id0:tapwrapper:j_id321">
+<div id="j_id0:tapwrapper:j_id321:j_id346"></div>
+</form>
+            <ul class="list-unstyled">
+               <li>
+                  <a data-language="en_US" onclick="ResetLanguage('en')">
+                  <span class="lang-lbl-full en" lang="en" style="padding-left:0;"></span> &nbsp; 
+                  </a>
+               </li>
+               <li>
+                  <a data-language="es_MX" onclick="ResetLanguageES('es')">
+                  <span class="lang-lbl-full es" lang="es" style="padding-left:0;"></span> &nbsp; 
+                  </a>
+               </li>
+               <li>
+                    <div style="display: flex;gap: 20px;margin-top: 2em;">
+                      <div>
+                         <a href="https://www.facebook.com/p/TAP-Greater-Los-Angeles-100069089864574/" target="_blank"><img height="auto" src="/resource/1705431091000/FacebookIcon" width="30"></a> 
+                      </div>
+                      <div>
+                         <a href="https://www.instagram.com/tapgreaterlosangeles/" target="_blank"><img height="auto" src="/resource/1705431130000/InstagramIcon" width="30"></a> 
+                      </div>
+                   </div>
+               </li>
+            </ul>
+         </div><span id="j_id0:tapwrapper:j_id328" style="display: none;"></span>
+      </div>
+   </div>
+  </footer>
 
   <script src="https://www.taptogo.net/resource/1738884380000/TapCommunity/js/bootstrap.min-min.js"></script>
   <script src="https://www.taptogo.net/resource/1738884380000/TapCommunity/js/app.min.js"></script>


### PR DESCRIPTION
## Summary
- add full TAP navigation with search and dropdowns
- remove duplicate heading list and keep footer at page bottom
- include full TAP footer with links and language controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7692f616c832b94a34d339e53331d