### PR TITLE
Include all Museo font weights

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,10 +10,101 @@
   <style>
     @font-face {
       font-family: 'museo_sans';
+      src: url('assets/fonts/MuseoSans-100-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSans-100-webfont.woff') format('woff');
+      font-weight: 100;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_sans';
+      src: url('assets/fonts/MuseoSans-100Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSans-100Italic-webfont.woff') format('woff');
+      font-weight: 100;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'museo_sans';
+      src: url('assets/fonts/MuseoSans-300-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSans-300-webfont.woff') format('woff');
+      font-weight: 300;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_sans';
+      src: url('assets/fonts/MuseoSans-300Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSans-300Italic-webfont.woff') format('woff');
+      font-weight: 300;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'museo_sans';
       src: url('assets/fonts/MuseoSans-500-webfont.woff2') format('woff2'),
            url('assets/fonts/MuseoSans-500-webfont.woff') format('woff');
       font-weight: 500;
       font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_sans';
+      src: url('assets/fonts/MuseoSans-500Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSans-500Italic-webfont.woff') format('woff');
+      font-weight: 500;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'museo_sans';
+      src: url('assets/fonts/MuseoSans-700-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSans-700-webfont.woff') format('woff');
+      font-weight: 700;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_sans';
+      src: url('assets/fonts/MuseoSans-700Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSans-700Italic-webfont.woff') format('woff');
+      font-weight: 700;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'museo_sans';
+      src: url('assets/fonts/MuseoSans-900-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSans-900-webfont.woff') format('woff');
+      font-weight: 900;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_sans';
+      src: url('assets/fonts/MuseoSans-900Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSans-900Italic-webfont.woff') format('woff');
+      font-weight: 900;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-100-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-100-webfont.woff') format('woff');
+      font-weight: 100;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-100Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-100Italic-webfont.woff') format('woff');
+      font-weight: 100;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-300-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-300-webfont.woff') format('woff');
+      font-weight: 300;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-300Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-300Italic-webfont.woff') format('woff');
+      font-weight: 300;
+      font-style: italic;
     }
     @font-face {
       font-family: 'museo_slab';
@@ -21,6 +112,55 @@
            url('assets/fonts/MuseoSlab-500-webfont.woff') format('woff');
       font-weight: 500;
       font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-500Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-500Italic-webfont.woff') format('woff');
+      font-weight: 500;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-700-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-700-webfont.woff') format('woff');
+      font-weight: 700;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-700Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-700Italic-webfont.woff') format('woff');
+      font-weight: 700;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-900-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-900-webfont.woff') format('woff');
+      font-weight: 900;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-900Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-900Italic-webfont.woff') format('woff');
+      font-weight: 900;
+      font-style: italic;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-1000-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-1000-webfont.woff') format('woff');
+      font-weight: 1000;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: 'museo_slab';
+      src: url('assets/fonts/MuseoSlab-1000Italic-webfont.woff2') format('woff2'),
+           url('assets/fonts/MuseoSlab-1000Italic-webfont.woff') format('woff');
+      font-weight: 1000;
+      font-style: italic;
     }
     body {
       display: flex;


### PR DESCRIPTION
## Summary
- add @font-face declarations for all MuseoSans weights (100–900) and styles
- add @font-face declarations for all MuseoSlab weights (100–1000) and styles

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a784f2d9f0832ba5d8b68a8c2643c5